### PR TITLE
Bump README to 0.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 This project is intended to provide SBT 0.12.0 plugin support for Scalastyle.
 For more information about Scalastyle, see http://www.scalastyle.org.
 
-This plugin uses version 0.3.1 of Scalastyle itself.
+This plugin uses version 0.3.2 of Scalastyle itself.
 
 ## Setup
 
 add following line to `project/plugins.sbt`
 
-    addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.3.1")
+    addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.3.2")
 
     resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"
 


### PR DESCRIPTION
Update the version number in the readme to 0.3.2.  

The readme says that the project uses its own plugin, but `project/plugins.sbt` has commented out the line that includes the plugin.  I didn't attempt to address, that bug figured I'd mention it.
