### PR TITLE
Add support for remote config file (downloads once per day)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@ and, inject plugin settings into project in `build.sbt`:
 You can check your code by typing `sbt scalastyle`.
 The result file is `target/scalastyle-result.xml` (CheckStyle compatible format).
 
-Scalastyle Configuration file is `./scalastyle-config.xml` by default.
+Scalastyle Configuration file is `./scalastyle-config.xml` by default. You can change this by changing the `config` setting (a `File`).
 To generate default configuration file, by typing `sbt scalastyle-generate-config`.
+
+### Remote Configuration Files
+
+If you want to use a remote configuration file, specify `scalastyleConfig` (an `Option[String]`) as a URI (`http(s)://` or `file://`) in your build:
+
+    import org.scalastyle.sbt.ScalastylePlugin
+    import org.scalastyle.sbt.PluginKeys.scalastyleConfigUrl
+
+    lazy val mySettings = ScalastylePlugin.Settings ++ Seq(
+      scalastyleConfig := Some("https://raw.githubusercontent.com/scalastyle/scalastyle-sbt-plugin/master/scalastyle-config.xml")
+    )
+
+Now this config will be downloaded locally to `target/scalastyle-config.xml`. If it is set to `None`, then this behavior will be ignored. You can also set `scalastyleConfig` to any path: for example, `scalastyleConfig := Some("scalastyle-config.xml")` will use the config file in your project root. This is equivalent to the aforementioned `config` setting, and it will take precedence over that setting if specified.
+
+By default, every 24 hours the remote config will be fetched again so as to keep you up to date. If you want to change that, set `scalastyleConfigUrlRefreshHours` in your build. It is a measure of hours until the next fetch (0 will cause it to always happen.)
 


### PR DESCRIPTION
Add two new keys:
1. `org.scalastyle.sbt.PluginKeys.scalastyleConfigUrl`. It is an `Option[String]`. Default `None`.
2. `org.scalastyle.sbt.PluginKeys.scalastyleConfigUrlRefreshTime`. It is an `Option[Integer]`. Default `Some(24)`.

To utilize this feature, set `scalastyleConfigUrl` in your `Build.scala` to be the URL at which your config file can be found. Now you will automatically download a new version of the config file remotely, so you keep up to date. By default you will update every 24 hours, but you can change `scalastyleConfigUrlRefreshTime` to change the rate at which that happens. 0 will have it always pull, and `None` will have it never pull.

If no local `scalastyle-config.xml` file is found, or if file was last modified more than `scalastyleConfigUrlRefreshTime` hours ago, then the URL will be used. The contents of the URL are downloaded to the `scalastyle-config.xml`. If it is not a correct URL or the file at the URL isn't good XML you will get an error. (Common exceptions are `java.net.MalformedUrlException`, `java.io.FileNotFoundException`, and `org.xml.sax.SAXParseException`.) If the download fails but there's still a local version of the config then things will proceed as normal.

If you want to manually force an update, you can delete your local config file or set `scalastyleConfigUrlRefreshTime := 0`.

This feature is not enabled by default (because `scalastyleConfigUrl := None`), so old behavior is preserved.

<hr>

This is in contrast to [my other PR](https://github.com/scalastyle/scalastyle-sbt-plugin/pull/24) which downloads every time. If you are doing that and you don't have a network connection, you won't be able to run scalastyle. You'd have to remember to manually download the config. On the other hand, this version will force you to either commit the `scalastyle-config.xml` or add it to your `.gitignore`. I leave both options up as a choice.
