### PR TITLE
Fixes #8: Add support for running scalastyle over test sources

### DIFF
--- a/src/sbt-test/test-scalastyle/config/build.sbt
+++ b/src/sbt-test/test-scalastyle/config/build.sbt
@@ -1,0 +1,20 @@
+org.scalastyle.sbt.ScalastylePlugin.Settings
+
+version := "0.1"
+ 
+scalaVersion := "2.10.0"
+
+org.scalastyle.sbt.PluginKeys.config in Test := file("scalastyle-test-config.xml")
+ 
+val containsMessage = taskKey[Boolean]("contains message")
+
+containsMessage := {
+    val search = "File length exceeds"
+    val filename = "target/scalastyle-test-result.xml"
+    val lines = sbt.IO.readLines(file(filename))
+    val contains = lines.find(s => s.contains(search)).isDefined
+    if (!contains) {
+        error("Could not find " + search + " in " + filename)
+    }
+    contains
+}

--- a/src/sbt-test/test-scalastyle/config/project/build.properties
+++ b/src/sbt-test/test-scalastyle/config/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.0

--- a/src/sbt-test/test-scalastyle/config/project/plugins.sbt
+++ b/src/sbt-test/test-scalastyle/config/project/plugins.sbt
@@ -1,0 +1,9 @@
+resolvers += "sonatype-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
+
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % pluginVersion)
+}

--- a/src/sbt-test/test-scalastyle/config/scalastyle-test-config.xml
+++ b/src/sbt-test/test-scalastyle/config/scalastyle-test-config.xml
@@ -1,0 +1,13 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[5]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+</scalastyle>

--- a/src/sbt-test/test-scalastyle/config/src/test/scala/hello.scala
+++ b/src/sbt-test/test-scalastyle/config/src/test/scala/hello.scala
@@ -1,0 +1,9 @@
+
+object Main extends App {
+  println("hello")
+}
+
+object foo {
+  println("hello")
+}
+

--- a/src/sbt-test/test-scalastyle/config/test
+++ b/src/sbt-test/test-scalastyle/config/test
@@ -1,0 +1,4 @@
+# scalastyle alternative config file
+> clean
+> test:scalastyle
+> containsMessage


### PR DESCRIPTION
This allows running scalastyle over test sources with `test:scalastyle`.  The results are in `target/scalastyle-test-result.xml` by default, but can be changed by setting `test:scalastyleTarget`.  By default `test:scalastyle` uses the same config file, but this can be changed by setting `config in Test`.
