### PR TITLE
Update sbt version to 0.13.6

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.6


### PR DESCRIPTION
Including this plugin in an auto-plugin somehow causes projects that include that plugin to load the older 0.13.0 sbt library, instead of the more current one configured in the plugin. This causes a compile-time error under some circumstances (see https://github.com/sbt/sbt/issues/1592). Building this plugin with 0.13.6 should solve the problem for the time being for plugins including it.
