### PR TITLE
Support running scalastyle over only files modified in a patch

### DIFF
--- a/src/sbt-test/patch/scalastyle/build.sbt
+++ b/src/sbt-test/patch/scalastyle/build.sbt
@@ -1,0 +1,16 @@
+version := "0.1"
+ 
+scalaVersion := "2.10.0"
+
+val containsMessage = taskKey[Boolean]("contains message")
+
+containsMessage := {
+    val search = "File length exceeds"
+    val filename = "target/scalastyle-result.xml"
+    val lines = sbt.IO.readLines(file(filename))
+    val contains = lines.find(s => s.contains(search)).isDefined
+    if (!contains) {
+        error("Could not find " + search + " in " + filename)
+    }
+    contains
+}

--- a/src/sbt-test/patch/scalastyle/patch.diff
+++ b/src/sbt-test/patch/scalastyle/patch.diff
@@ -1,0 +1,12 @@
+diff --git a/src/main/scala/hello.scala b/src/main/scala/hello.scala
+index 3cb4df3..cf34b91 100644
+--- a/src/main/scala/hello.scala
++++ b/src/main/scala/hello.scala
+@@ -3,6 +3,7 @@ object Main extends App {
+   println("hello")
+ }
+ 
++// foo
+ object foo {
+   println("hello")
+ }

--- a/src/sbt-test/patch/scalastyle/project/build.properties
+++ b/src/sbt-test/patch/scalastyle/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.0

--- a/src/sbt-test/patch/scalastyle/project/plugins.sbt
+++ b/src/sbt-test/patch/scalastyle/project/plugins.sbt
@@ -1,0 +1,9 @@
+resolvers += "sonatype-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
+
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % pluginVersion)
+}

--- a/src/sbt-test/patch/scalastyle/scalastyle-config.xml
+++ b/src/sbt-test/patch/scalastyle/scalastyle-config.xml
@@ -1,0 +1,13 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[5]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+</scalastyle>

--- a/src/sbt-test/patch/scalastyle/src/main/scala/hello.scala
+++ b/src/sbt-test/patch/scalastyle/src/main/scala/hello.scala
@@ -1,0 +1,3 @@
+object Main extends App {
+  println("hello")
+}

--- a/src/sbt-test/patch/scalastyle/src/main/scala/hello2.scala
+++ b/src/sbt-test/patch/scalastyle/src/main/scala/hello2.scala
@@ -1,0 +1,10 @@
+
+object Main extends App {
+  println("hello")
+}
+
+// foo
+object foo {
+  println("hello")
+}
+

--- a/src/sbt-test/patch/scalastyle/test
+++ b/src/sbt-test/patch/scalastyle/test
@@ -1,0 +1,5 @@
+# scalastyle from patch file
+> clean
+> scalastyle patch.diff
+# The errors appear in the file that is not included in the patch, so this is expected to fail
+-> containsMessage


### PR DESCRIPTION
If you give the scalastyle task the path to a patch file as an argument, it will process only the files modified in that patch.  The regex used to extract the file names from the patch is configurable.