### PR TITLE
Read sources files from sbt instead of scalaSource

### DIFF
--- a/src/main/scala/org/scalastyle/sbt/Plugin.scala
+++ b/src/main/scala/org/scalastyle/sbt/Plugin.scala
@@ -109,8 +109,8 @@ object ScalastylePlugin extends Plugin {
       (scalastyleTarget in Test) := target.value / "scalastyle-test-result.xml",
       scalastyleFailOnError := true,
       (scalastyleFailOnError in Test) := (scalastyleFailOnError in scalastyle).value,
-      scalastyleSources := Seq(scalaSource.value),
-      (scalastyleSources in Test) := (scalastyleSources in scalastyle).value
+      scalastyleSources := Seq((scalaSource in Compile).value),
+      (scalastyleSources in Test) := Seq((scalaSource in Test).value)
     ) ++
     Project.inConfig(Compile)(rawScalastyleSettings()) ++
     Project.inConfig(Test)(rawScalastyleSettings())


### PR DESCRIPTION
This is to enable us to run scalastyle with sources that are dynamically added when we are using sbt.
(for example, we can use sbt-maven-plugin and build-helper-maven-plugin to add some additional source file, check https://github.com/apache/spark/blob/master/sql/hive-thriftserver/pom.xml )

Originally, scalastyle-sbt-plugin would call scalaSource of sbt command to get all the files that need to be checked, but this would omit those file that not in `src/main/scala/{groupId}/xxx`.

In this patch, we are calling sources of sbt command, and get all the files that the sbt would compile.



/cc @matthewfarwell 
This is a solution to https://issues.apache.org/jira/browse/SPARK-4331
