### PR TITLE
Fix scalastyleConfig in multi-project builds

### DIFF
--- a/src/sbt-test/multi-scalastyle/config/build.sbt
+++ b/src/sbt-test/multi-scalastyle/config/build.sbt
@@ -1,0 +1,30 @@
+lazy val containsMessage = taskKey[Boolean]("contains message")
+
+lazy val commonSettings = Seq(
+  version := "0.1",
+  scalaVersion := "2.10.0",
+  scalastyleConfig in Test := (baseDirectory in ThisBuild).value / "scalastyle-test-config.xml",
+  containsMessage := {
+    val search = "File length exceeds"
+    val filename = (scalastyleTarget in Test).value
+    val lines = sbt.IO.readLines(filename)
+    val contains = lines exists (_ contains search)
+    if (!contains) {
+      error("Could not find " + search + " in " + filename)
+    }
+    contains
+  }
+)
+
+lazy val root = (project in file(".")).
+  aggregate(sub1, sub2).
+  settings(commonSettings: _*).
+  settings(containsMessage := {
+    true
+  })
+
+lazy val sub1 = (project in file("sub1")).
+  settings(commonSettings: _*)
+
+lazy val sub2 = (project in file("sub2")).
+  settings(commonSettings: _*)

--- a/src/sbt-test/multi-scalastyle/config/project/build.properties
+++ b/src/sbt-test/multi-scalastyle/config/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.5

--- a/src/sbt-test/multi-scalastyle/config/project/plugins.sbt
+++ b/src/sbt-test/multi-scalastyle/config/project/plugins.sbt
@@ -1,0 +1,9 @@
+resolvers += "sonatype-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
+
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % pluginVersion)
+}

--- a/src/sbt-test/multi-scalastyle/config/scalastyle-test-config.xml
+++ b/src/sbt-test/multi-scalastyle/config/scalastyle-test-config.xml
@@ -1,0 +1,13 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[5]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+</scalastyle>

--- a/src/sbt-test/multi-scalastyle/config/sub1/src/test/scala/hello.scala
+++ b/src/sbt-test/multi-scalastyle/config/sub1/src/test/scala/hello.scala
@@ -1,0 +1,9 @@
+
+object Main extends App {
+  println("hello")
+}
+
+object foo {
+  println("hello")
+}
+

--- a/src/sbt-test/multi-scalastyle/config/sub2/src/test/scala/hello.scala
+++ b/src/sbt-test/multi-scalastyle/config/sub2/src/test/scala/hello.scala
@@ -1,0 +1,9 @@
+
+object Main extends App {
+  println("hello")
+}
+
+object foo {
+  println("hello")
+}
+

--- a/src/sbt-test/multi-scalastyle/config/test
+++ b/src/sbt-test/multi-scalastyle/config/test
@@ -1,0 +1,4 @@
+# scalastyle alternative config file
+> clean
+> test:scalastyle
+> containsMessage


### PR DESCRIPTION
This is to get the plugin to properly work with multi-projects build.
This PR should resolve #42 and resolve #44 
It's using the _auto-plugins_ feature introduced in 0.13.5, the downside is that it will only be compatible with sbt 0.13.5+
