### PR TITLE
Migrate to SBT AutoPlugin and require manual installation

### DIFF
--- a/src/main/scala/org/scalastyle/sbt/Plugin.scala
+++ b/src/main/scala/org/scalastyle/sbt/Plugin.scala
@@ -61,16 +61,19 @@ import java.net.URL
 object ScalastylePlugin extends AutoPlugin {
   import sbt.complete.DefaultParsers._
 
-  val scalastyle = inputKey[Unit]("Run scalastyle on your code")
-  val scalastyleGenerateConfig = taskKey[Unit]("Generate a default configuration files for scalastyle")
+  object autoImport {
+    val scalastyle = inputKey[Unit]("Run scalastyle on your code")
+    val scalastyleGenerateConfig = taskKey[Unit]("Generate a default configuration files for scalastyle")
 
-  val scalastyleTarget = settingKey[File]("XML output file from scalastyle")
-  val scalastyleConfig = settingKey[File]("Scalastyle configuration file")
-  val scalastyleConfigUrl = settingKey[Option[URL]]("Scalastyle configuration file as a URL")
-  val scalastyleFailOnError = settingKey[Boolean]("If true, Scalastyle will fail the task when an error level rule is violated")
-  val scalastyleConfigRefreshHours = settingKey[Integer]("How many hours until next run will fetch the scalastyle-config.xml again if location is a URI.")
-  val scalastyleConfigUrlCacheFile = settingKey[String]("If scalastyleConfigUrl is set, it will be cached here")
-  val scalastyleSources = settingKey[Seq[File]]("Which sources will scalastyle check")
+    val scalastyleTarget = settingKey[File]("XML output file from scalastyle")
+    val scalastyleConfig = settingKey[File]("Scalastyle configuration file")
+    val scalastyleConfigUrl = settingKey[Option[URL]]("Scalastyle configuration file as a URL")
+    val scalastyleFailOnError = settingKey[Boolean]("If true, Scalastyle will fail the task when an error level rule is violated")
+    val scalastyleConfigRefreshHours = settingKey[Integer]("How many hours until next run will fetch the scalastyle-config.xml again if location is a URI.")
+    val scalastyleConfigUrlCacheFile = settingKey[String]("If scalastyleConfigUrl is set, it will be cached here")
+    val scalastyleSources = settingKey[Seq[File]]("Which sources will scalastyle check")
+  }
+  import autoImport._
 
   def rawScalastyleSettings(): Seq[sbt.Def.Setting[_]] =
     Seq(

--- a/src/sbt-test/config/fail-on-error/build.sbt
+++ b/src/sbt-test/config/fail-on-error/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 scalastyleFailOnError := false
 
 version := "0.1"

--- a/src/sbt-test/config/fail-on-error/project/build.properties
+++ b/src/sbt-test/config/fail-on-error/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/config/scalastyle-config/build.sbt
+++ b/src/sbt-test/config/scalastyle-config/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 scalastyleConfig := file("alternative-config.xml")
 
 version := "0.1"

--- a/src/sbt-test/config/scalastyle-config/project/build.properties
+++ b/src/sbt-test/config/scalastyle-config/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/config/scalastyle-http/build.sbt
+++ b/src/sbt-test/config/scalastyle-http/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 scalastyleConfigUrl := Some(url("http://www.scalastyle.org/scalastyle_config.xml"))
 
 version := "0.1"

--- a/src/sbt-test/config/scalastyle-http/project/build.properties
+++ b/src/sbt-test/config/scalastyle-http/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/config/scalastyle-target/build.sbt
+++ b/src/sbt-test/config/scalastyle-target/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 scalastyleTarget := file("target/scalastyle-output.xml")
 
 version := "0.1"

--- a/src/sbt-test/config/scalastyle-target/project/build.properties
+++ b/src/sbt-test/config/scalastyle-target/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/errors-warnings/error/build.sbt
+++ b/src/sbt-test/errors-warnings/error/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/errors-warnings/error/project/build.properties
+++ b/src/sbt-test/errors-warnings/error/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/errors-warnings/info/build.sbt
+++ b/src/sbt-test/errors-warnings/info/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/errors-warnings/info/project/build.properties
+++ b/src/sbt-test/errors-warnings/info/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/errors-warnings/warning/build.sbt
+++ b/src/sbt-test/errors-warnings/warning/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/errors-warnings/warning/project/build.properties
+++ b/src/sbt-test/errors-warnings/warning/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/generate/generate-directory/build.sbt
+++ b/src/sbt-test/generate/generate-directory/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 scalastyleConfig := file("foo/scalastyle-config.xml")
 
 version := "0.1"

--- a/src/sbt-test/generate/generate-directory/project/build.properties
+++ b/src/sbt-test/generate/generate-directory/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/generate/generate/build.sbt
+++ b/src/sbt-test/generate/generate/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/generate/test-generate/build.sbt
+++ b/src/sbt-test/generate/test-generate/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 scalastyleConfig := file("scalastyle-config.xml")
 
 (scalastyleConfig in Test) := file("test-scalastyle-config.xml")

--- a/src/sbt-test/generate/test-generate/project/build.properties
+++ b/src/sbt-test/generate/test-generate/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/messages/real-messages/build.sbt
+++ b/src/sbt-test/messages/real-messages/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/messages/real-messages/project/build.properties
+++ b/src/sbt-test/messages/real-messages/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/specific-files/directories/build.sbt
+++ b/src/sbt-test/specific-files/directories/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/specific-files/directories/project/build.properties
+++ b/src/sbt-test/specific-files/directories/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/specific-files/files/build.sbt
+++ b/src/sbt-test/specific-files/files/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/specific-files/files/project/build.properties
+++ b/src/sbt-test/specific-files/files/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/specific-files/nonexistent-file/build.sbt
+++ b/src/sbt-test/specific-files/nonexistent-file/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/specific-files/nonexistent-file/project/build.properties
+++ b/src/sbt-test/specific-files/nonexistent-file/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/test-config/fail-on-error/build.sbt
+++ b/src/sbt-test/test-config/fail-on-error/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 (scalastyleFailOnError in Test) := false
 
 version := "0.1"

--- a/src/sbt-test/test-config/fail-on-error/project/build.properties
+++ b/src/sbt-test/test-config/fail-on-error/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/test-config/scalastyle-config/build.sbt
+++ b/src/sbt-test/test-config/scalastyle-config/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 (scalastyleConfig in Test) := file("gggalternative-config.xml")
 
 version := "0.1"

--- a/src/sbt-test/test-config/scalastyle-config/project/build.properties
+++ b/src/sbt-test/test-config/scalastyle-config/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/test-config/scalastyle-http/build.sbt
+++ b/src/sbt-test/test-config/scalastyle-http/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 (scalastyleConfigUrl in Test) := Some(url("http://www.scalastyle.org/scalastyle_config.xml"))
 
 version := "0.1"

--- a/src/sbt-test/test-config/scalastyle-http/project/build.properties
+++ b/src/sbt-test/test-config/scalastyle-http/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/test-config/scalastyle-target/build.sbt
+++ b/src/sbt-test/test-config/scalastyle-target/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 (scalastyleTarget in Test) := file("target/scalastyle-output.xml")
 
 version := "0.1"

--- a/src/sbt-test/test-config/scalastyle-target/project/build.properties
+++ b/src/sbt-test/test-config/scalastyle-target/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/test-errors-warnings/error/build.sbt
+++ b/src/sbt-test/test-errors-warnings/error/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/test-errors-warnings/error/project/build.properties
+++ b/src/sbt-test/test-errors-warnings/error/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/test-errors-warnings/info/build.sbt
+++ b/src/sbt-test/test-errors-warnings/info/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/test-errors-warnings/info/project/build.properties
+++ b/src/sbt-test/test-errors-warnings/info/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/test-errors-warnings/warning/build.sbt
+++ b/src/sbt-test/test-errors-warnings/warning/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/test-errors-warnings/warning/project/build.properties
+++ b/src/sbt-test/test-errors-warnings/warning/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/src/sbt-test/test-scalastyle/config/build.sbt
+++ b/src/sbt-test/test-scalastyle/config/build.sbt
@@ -1,3 +1,5 @@
+val p = (project in file(".")).enablePlugins(ScalastylePlugin)
+
 version := "0.1"
  
 scalaVersion := "2.10.0"

--- a/src/sbt-test/test-scalastyle/config/project/build.properties
+++ b/src/sbt-test/test-scalastyle/config/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5


### PR DESCRIPTION
Fixes #48 

Using the new `AutoPlugin` feature allows users to choose when to install the Scalastyle plugin. In a multi-project build where Scalastyle is only needed for some sub-projects, this is a critical feature. This also allows other `AutoPlugin` to override the default values.

Example project to enable the Scalastyle plugin:

```
val test = (project in file(".")).enablePlugins(ScalastylePlugin)
```
