### PR TITLE
Feature: fail-on-warning option

### DIFF
--- a/src/sbt-test/config/fail-on-warning/build.sbt
+++ b/src/sbt-test/config/fail-on-warning/build.sbt
@@ -1,0 +1,6 @@
+scalastyleFailOnWarning := true
+
+version := "0.1"
+ 
+scalaVersion := "2.10.0"
+ 

--- a/src/sbt-test/config/fail-on-warning/project/plugins.sbt
+++ b/src/sbt-test/config/fail-on-warning/project/plugins.sbt
@@ -1,0 +1,9 @@
+resolvers += "sonatype-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
+
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % pluginVersion)
+}

--- a/src/sbt-test/config/fail-on-warning/scalastyle-config.xml
+++ b/src/sbt-test/config/fail-on-warning/scalastyle-config.xml
@@ -1,0 +1,8 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[5]]></parameter>
+  </parameters>
+ </check>
+</scalastyle>

--- a/src/sbt-test/config/fail-on-warning/src/main/scala/hello.scala
+++ b/src/sbt-test/config/fail-on-warning/src/main/scala/hello.scala
@@ -1,0 +1,9 @@
+
+object Main extends App {
+  println("hello")
+}
+
+object foo {
+  println("hello")
+}
+

--- a/src/sbt-test/config/fail-on-warning/test
+++ b/src/sbt-test/config/fail-on-warning/test
@@ -1,0 +1,3 @@
+# scalastyle with warnings => failure
+> clean
+-> scalastyle

--- a/src/sbt-test/test-config/fail-on-warning/build.sbt
+++ b/src/sbt-test/test-config/fail-on-warning/build.sbt
@@ -1,0 +1,6 @@
+(scalastyleFailOnWarning in Test) := true
+
+version := "0.1"
+ 
+scalaVersion := "2.10.0"
+ 

--- a/src/sbt-test/test-config/fail-on-warning/project/plugins.sbt
+++ b/src/sbt-test/test-config/fail-on-warning/project/plugins.sbt
@@ -1,0 +1,9 @@
+resolvers += "sonatype-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
+
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % pluginVersion)
+}

--- a/src/sbt-test/test-config/fail-on-warning/scalastyle-config.xml
+++ b/src/sbt-test/test-config/fail-on-warning/scalastyle-config.xml
@@ -1,0 +1,8 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[5]]></parameter>
+  </parameters>
+ </check>
+</scalastyle>

--- a/src/sbt-test/test-config/fail-on-warning/src/test/scala/hello.scala
+++ b/src/sbt-test/test-config/fail-on-warning/src/test/scala/hello.scala
@@ -1,0 +1,9 @@
+
+object Main extends App {
+  println("hello")
+}
+
+object foo {
+  println("hello")
+}
+

--- a/src/sbt-test/test-config/fail-on-warning/test
+++ b/src/sbt-test/test-config/fail-on-warning/test
@@ -1,0 +1,3 @@
+# scalastyle with warnings => failure
+> clean
+-> test:scalastyle


### PR DESCRIPTION
#### Feature
Added parameter `scalastyleFailOnWarning`. If true, the scalastyle task fails if any messages at warning level are output. Default value is `false`.

Feature #58 requested by @zgraggen, PR suggested by @matthewfarwell.

#### Tests
* Test case `config/fail-on-warning` added. `scalastyleFailOnWarning` is `true` and expects scalastyle execution to fail.
* Analogue `test-config/fail-on-warning`
* Case where the option is disabled is default and covered by other tests.

#### Result
Closes #58 and #18 