### PR TITLE
Add input file encoding setting.

### DIFF
--- a/src/sbt-test/config/scalastyle-input-encoding/build.sbt
+++ b/src/sbt-test/config/scalastyle-input-encoding/build.sbt
@@ -1,0 +1,6 @@
+scalastyleTarget := file("target/scalastyle-output.xml")
+
+version := "0.1"
+ 
+scalaVersion := "2.10.0"
+ 

--- a/src/sbt-test/config/scalastyle-input-encoding/project/plugins.sbt
+++ b/src/sbt-test/config/scalastyle-input-encoding/project/plugins.sbt
@@ -1,0 +1,9 @@
+resolvers += "sonatype-snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
+
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % pluginVersion)
+}

--- a/src/sbt-test/config/scalastyle-input-encoding/scalastyle-config.xml
+++ b/src/sbt-test/config/scalastyle-input-encoding/scalastyle-config.xml
@@ -1,0 +1,13 @@
+<scalastyle>
+ <name>Scalastyle standard configuration</name>
+ <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="true">
+  <parameters>
+   <parameter name="maxFileLength"><![CDATA[5]]></parameter>
+  </parameters>
+ </check>
+ <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+  <parameters>
+   <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+  </parameters>
+ </check>
+</scalastyle>

--- a/src/sbt-test/config/scalastyle-input-encoding/src/main/scala/hello.scala
+++ b/src/sbt-test/config/scalastyle-input-encoding/src/main/scala/hello.scala
@@ -1,0 +1,10 @@
+
+object Main extends App {
+  println("hello")
+  println("网址")
+}
+
+object foo {
+  println("hello")
+}
+

--- a/src/sbt-test/config/scalastyle-input-encoding/test
+++ b/src/sbt-test/config/scalastyle-input-encoding/test
@@ -1,0 +1,5 @@
+# scalastyle with UTF-8 input file
+-> scalastyle
+> 'set scalastyleInputEncoding := Some(scala.io.Codec.UTF8.name)'
+> scalastyle
+$ exists target/scalastyle-output.xml


### PR DESCRIPTION
Adds `scalastyleInputEncoding` with default `None` for backwards compatibility, and passes the value to the required function.
Adds a test to confirm UTF-8 character encoding works.

Closes #22 
